### PR TITLE
Fixed Truncated incorrect DOUBLE value error

### DIFF
--- a/World/Updates/Rel21/Rel21_09_029_Nightlash_Summon_Support..sql
+++ b/World/Updates/Rel21/Rel21_09_029_Nightlash_Summon_Support..sql
@@ -59,7 +59,7 @@ BEGIN
 
     SET @summonid := (SELECT MAX(id) FROM `creature_ai_summons`);
 	-- Remove current Nightlash placeholder.
-	DELETE FROM `creature_ai_summons` WHERE `comment` = 1983;
+	DELETE FROM `creature_ai_summons` WHERE `comment` = '1983';
 	-- Added script summon location.
 	INSERT INTO `creature_ai_summons` (`id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `comment`) VALUES(@summonid+1,1073.84,1543.37,28.6752,0.174533,300000,1983);
 	-- Added 10% chance to summon Nightlash. 


### PR DESCRIPTION
When I attempt to run this SQL script, the statement on line 62 would fail. Adding quotes solved the issue, and the sql script now runs successfully on MySQL Server (5.7.24-0ubuntu0.18.04.1). I tested the changes with getmangos.sh, and now completes successfully on the database phase.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosone/database/96)
<!-- Reviewable:end -->
